### PR TITLE
[fix] Replace torch.Tensor typing with the proper transfomers' BatchFeature

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,8 +6,8 @@ This module here is the entrypoint to the VLM Competence toolkit.
 import logging
 import os
 
-import torch
 from PIL import Image
+from transformers.feature_extraction_utils import BatchFeature
 
 from models import llava, qwen
 from models.base import ModelBase
@@ -36,7 +36,7 @@ def get_model(
             return qwen.QwenModel(config)
 
 
-def load_image_data(config: Config, model: ModelBase) -> torch.Tensor:
+def load_image_data(config: Config, model: ModelBase) -> BatchFeature:
     """From a configuration, loads the input image data.
 
     Args:
@@ -45,7 +45,7 @@ def load_image_data(config: Config, model: ModelBase) -> torch.Tensor:
         model (ModelBase): The model to use for generating the processor
 
     Returns:
-        torch.Tensor: The data as a torch tensor
+        data (BatchFeature): The input data dictionary
     """
     logging.debug('Loading data...')
     imgs = [

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 
 import torch
 from transformers import AutoProcessor
+from transformers.feature_extraction_utils import BatchFeature
 
 from .config import Config
 
@@ -88,11 +89,11 @@ class ModelBase(ABC):
                 'No hooks were registered. Double-check the configured modules.'
             )
 
-    def forward(self, data: torch.Tensor):
+    def forward(self, data: BatchFeature):
         """Given some data, performs a single forward pass.
 
         Args:
-            data (torch.Tensor): The input data tensor
+            data (BatchFeature): The input data dictionary
         """
         logging.debug('Starting forward pass')
         with torch.no_grad():


### PR DESCRIPTION
This is a quick fix for the comment found here: https://github.com/compling-wat/vlm-competence-dev/pull/6#discussion_r1957355630