### PR TITLE
[fix] Set the model to eval mode for deterministic behaviour

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -97,6 +97,3 @@ if __name__ == '__main__':
     model = get_model(config.architecture, config)
     model.forward(load_image_data(config, model))
     model.save_states()
-
-    # TODO: Look at setting the model to eval
-    # make sure that the train part doesn't introduce stochasticity

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -96,6 +96,7 @@ class ModelBase(ABC):
             data (BatchFeature): The input data dictionary
         """
         logging.debug('Starting forward pass')
+        self.model.eval()
         with torch.no_grad():
             _ = self.model(**data)
         logging.debug('Completed forward pass...')


### PR DESCRIPTION
Tested this by running it twice and running `diff` on the output files, resulting in the exact same tensor outputs.