### PR TITLE
[fix] Converted switch block to if/else block

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -29,11 +29,10 @@ def get_model(
     Returns:
         base.ModelBase: A model of type ModelBase which implements the runtime
     """
-    match model_arch:
-        case ModelSelection.LLAVA:
-            return llava.LlavaModel(config)
-        case ModelSelection.QWEN:
-            return qwen.QwenModel(config)
+    if model_arch == ModelSelection.LLAVA:
+        return llava.LlavaModel(config)
+    elif model_arch == ModelSelection.QWEN:
+        return qwen.QwenModel(config)
 
 
 def load_image_data(config: Config, model: ModelBase) -> torch.Tensor:
@@ -98,5 +97,3 @@ if __name__ == '__main__':
     model.forward(load_image_data(config, model))
     model.save_states()
 
-    # TODO: Look at setting the model to eval
-    # make sure that the train part doesn't introduce stochasticity


### PR DESCRIPTION
This is more Python version-agnostic as switch blocks are not available in `python<10` environments.