### PR TITLE
[fix] Fix image handling by preprocessing the image file paths

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,7 @@ def get_model(
 
 
 if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
     config = Config()
     logging.debug(
         f'Config is set to '

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -156,15 +156,16 @@ class ModelBase(ABC):
         Returns:
             dict: The processor arguments.
         """
+        has_images = self.config.has_images()
         processor_args = {
             'text': (
                 [prompt for _ in self.config.image_paths]
-                if self.config.has_images() else
+                if has_images else
                 prompt
             ),
             'return_tensors': 'pt'
         }
-        if self.config.has_images():
+        if has_images:
             processor_args['images'] = [
                 Image.open(img_path).convert('RGB')
                 for img_path in self.config.image_paths

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -107,7 +107,7 @@ class Config():
             hasattr(self, 'debug') and self.debug
         )
         if self.debug:
-            logging.basicConfig(level=logging.DEBUG)
+            logging.getLogger().setLevel(logging.DEBUG)
 
         # require that the architecture and the model path to exist
         assert hasattr(self, 'architecture') and hasattr(self, 'model_path'), (
@@ -154,8 +154,6 @@ class Config():
                     os.listdir(self.input_dir)
                 )
             ]
-
-        logging.debug(self.image_paths)
 
         # check if there is no input data
         if not (self.has_images() or hasattr(self, 'prompt')):


### PR DESCRIPTION
This change will preprocess the image file paths within config initialization alongside the proper checks as well.

It also helps fix the debug logging to be set within the config, and if multiple configs are created, takes the highest debug state, i.e. if only one config sets debug to true, then it will be set to debug.