### PR TITLE
[fix] Quick fix: format output states file name

### DIFF
--- a/src/models/base.py
+++ b/src/models/base.py
@@ -143,7 +143,7 @@ class ModelBase(ABC):
                 state,
                 os.path.join(
                     self.config.output_dir,
-                    f'state_{name}_{self.config.architecture.value}.pt'
+                    f"state-{name.replace('.', '_')}-{self.config.architecture.value}.pt"
                 )
             )
 


### PR DESCRIPTION
## What does this PR do?

This PR is a very quick fix of the `ModelBase.save_states()` to format the output file name for the convenience of file name matching.

## Changes

- Change output model name from `"ModelSelection.<Model>"` to `"model"`.
- Replace any `'.'` inside module name into `'_'` (so that module names only consist of alphabets, numbers, and `'_'`).
- Replace the connecting symbol between domains from `'_'` to `'-'` so that it does not overlap with module names.