### PR TITLE
[fix] Fixes the saving of torch tensors using torch.save()

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,5 @@ git submodule update --recursive --init
 ## Running with different filters
 We also provide a separate script that relies on the main functionality to run on multiple different filters, which can override the specific layer, prompt and input image directories, defaulting to the original layer, prompt and input image directories. This is specified through configs with the `-fc` or `--filter-config` flags as:
 ```
-python src/main.py --config configs/clip-base.yaml --filter-config configs/clip-base-filter.yaml --debug
+python src/run_filters.py --config configs/clip-base.yaml --filter-config configs/clip-base-filter.yaml --debug
 ```

--- a/scripts/read_tensor.py
+++ b/scripts/read_tensor.py
@@ -2,10 +2,9 @@
 
 Outputs the layers and its specific associated tensors.
 """
-
+import io
 import logging
 import os
-import pickle
 import sqlite3
 import sys
 from typing import List, Tuple
@@ -72,7 +71,7 @@ def retrieve_tensors(
     tensors = []
     for result in results:
         layer, tensor, timestamp, image_path, prompt = result
-        tensor = pickle.loads(tensor)
+        tensor = torch.load(io.BytesIO(tensor), map_location=config.device)
         tensors.append((layer, tensor, timestamp, image_path, prompt))
 
     return tensors

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -3,9 +3,9 @@
 Provides the common classes used such as the ModelSelection enum as well as the
 abstract base class for models.
 """
+import io
 import logging
 import os
-import pickle
 import sqlite3
 from abc import ABC, abstractmethod
 from typing import List, Tuple, TypeAlias
@@ -111,7 +111,8 @@ class ModelBase(ABC):
             cursor = self.connection.cursor()
 
             # Convert the tensor to a binary blob
-            tensor_blob = pickle.dumps(output)
+            tensor_blob = io.BytesIO()
+            torch.save(output, tensor_blob)
 
             # Insert the tensor into the table
             cursor.execute(f"""
@@ -124,7 +125,7 @@ class ModelBase(ABC):
                     image_path,
                     prompt,
                     name,
-                    tensor_blob
+                    tensor_blob.getvalue()
                 )
             )
 


### PR DESCRIPTION
Instead of using pickle dumps, we are using torch.save so that we can switch to other devices a lot more easily, as shown with the map_location flag.

This tackles issue https://github.com/compling-wat/vlm-competence-dev/issues/33.