### PR TITLE
[fix] Python 3.9 compatible changes

### DIFF
--- a/src/models/base.py
+++ b/src/models/base.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sqlite3
 from abc import ABC, abstractmethod
-from typing import List, Tuple, TypeAlias
+from typing import List, Tuple
 
 import torch
 from PIL import Image
@@ -17,7 +17,7 @@ from transformers.feature_extraction_utils import BatchFeature
 
 from .config import Config
 
-ModelInput: TypeAlias = Tuple[str, str, BatchFeature]
+ModelInput = Tuple[str, str, BatchFeature]
 
 
 class ModelBase(ABC):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -7,7 +7,7 @@ import argparse
 import logging
 import os
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 import regex as re
 import torch
@@ -231,11 +231,11 @@ class Config():
         """
         self.modules = [re.compile(module) for module in to_match_modules]
 
-    def set_image_paths(self, input_dir: (str | None)):
+    def set_image_paths(self, input_dir: Optional[str]):
         """Sets the images based on the input directory.
 
         Args:
-            input_dir (str | None): The input directory.
+            input_dir (Optional[str]): The input directory.
         """
         if input_dir is None:
             return


### PR DESCRIPTION
Changed some sections of the codebase that are only available in Python 3.10+ environments, as InternLM-XC (and other models) use Python 3.9. This includes:
- changing `str | None` to use `typing.Optional` instead
- removing use of `typing.TypeAlias`

## Summary by Sourcery

Ensure compatibility with Python 3.9 by replacing PEP 604 union type hints with typing.Optional and removing typing.TypeAlias usage.

Bug Fixes:
- Replace `str | None` annotations with `Optional[str]` in `set_image_paths` for Python 3.9 compatibility
- Remove `TypeAlias` usage in model input alias definition to support Python 3.9